### PR TITLE
Fix betting rules and retain dice on table

### DIFF
--- a/src/betting/index.js
+++ b/src/betting/index.js
@@ -1,9 +1,15 @@
 import * as THREE from 'three';
-import { player } from '../state/player';
+import { player, gameState } from '../state/player';
+import { displayMessage } from '../ui/message';
 
 let betChips = [];
 
 export function placeBet(amount, playerX, throwZ, scene, updateBalanceDisplay) {
+  if (!gameState.canBet) {
+    displayMessage('Bets are locked until the round is over.');
+    return;
+  }
+
   if (!player.balance || player.balance < amount) return;
   player.balance -= amount;
   player.currentBet += amount;
@@ -12,7 +18,7 @@ export function placeBet(amount, playerX, throwZ, scene, updateBalanceDisplay) {
 }
 
 export function updateChipDisplay(playerX, throwZ, scene) {
-  clearChips(scene);
+  clearChips();
   const chips = consolidateChips(player.currentBet);
   const maxChipsPerStack = 20;
   let stackCount = 0;
@@ -30,8 +36,10 @@ export function updateChipDisplay(playerX, throwZ, scene) {
   });
 }
 
-export function clearChips(scene) {
-  betChips.forEach(c => scene.remove(c));
+export function clearChips() {
+  betChips.forEach(c => {
+    if (c.parent) c.parent.remove(c);
+  });
   betChips = [];
 }
 

--- a/src/dice/index.js
+++ b/src/dice/index.js
@@ -40,7 +40,7 @@ export function spawnDice(scene, world, playerX, throwZ) {
   const d2 = createDie(new THREE.Vector3(playerX + 0.3, 1.2, throwZ));
 
   dice.push(d1, d2);
-  scene.add(d1.mesh, d2.mesh);
+  scene.add(d1.mesh);
   scene.add(d2.mesh);
   world.addBody(d1.body);
   world.addBody(d2.body);

--- a/src/logic/rollHandler.js
+++ b/src/logic/rollHandler.js
@@ -1,6 +1,7 @@
 // src/logic/rollHandler.js
 import { getTopFace } from '../dice/index';
-import { player, gameState, updateBalanceDisplay } from '../state/player';
+import { player, gameState } from '../state/player';
+import { updateBalanceDisplay } from '../ui/balance';
 import { displayMessage } from '../ui/message';
 import { clearChips } from '../betting';
 

--- a/src/main.js
+++ b/src/main.js
@@ -2,44 +2,43 @@
 import * as THREE from 'three';
 import { Vec3 } from 'cannon-es';
 
-import { setupSceneAndRenderer, setupPhysicsWorld, setupTableAndWalls } from './environment/setup.js';
-
+import {
+  setupSceneAndRenderer,
+  setupPhysicsWorld,
+  setupTableAndWalls
+} from './environment/setup.js';
 
 
 import { initControls } from './ui/controls.js';
-import { createDie, getTopFace } from './dice/index.js';
-import { initializeBalanceDisplay, updateBalanceDisplay } from './ui/balance.js';
-import { placeBet, updateChipDisplay, clearChips } from './betting/index.js';
-import { setupUI, messagePanel } from './ui/index.js';
+import { createDie } from './dice/index.js';
+import { updateBalanceDisplay } from './ui/balance.js';
+import { placeBet } from './betting/index.js';
+import { setupUI } from './ui/index.js';
 import { checkRoll } from './logic/rollHandler.js';
+import { player, gameState } from './state/player.js';
+import { displayMessage } from './ui/message.js';
 
-const {
-  scene,
-  camera,
-  renderer,
-  throwZ,
-  diceMaterial,
-  world,
-  tableWidth
-} = setupSceneAndRenderer();
-
-setupPhysicsWorld(world);
-setupTableAndWalls(scene, world);
+const { scene, camera, renderer } = setupSceneAndRenderer();
+const world = setupPhysicsWorld();
+const { tableWidth } = setupTableAndWalls(scene, world);
+const throwZ = tableWidth / 2 - 4;
 initControls(camera, renderer);
-initializeBalanceDisplay();
-setupUI(() => spawnDice(), (amount) => placeBet(amount, playerX, throwZ, scene, updateBalanceDisplay));
+setupUI(spawnDice, (amount) => placeBet(amount, playerX, throwZ, scene, updateBalanceDisplay));
 
 let playerX = 0;
 let dice = [];
 let waitingForRollToSettle = false;
-let rollDisplayPending = false;
-let rollTimer = 0;
 
 function spawnDice() {
+  if (gameState.phase === 'comeOut' && player.currentBet === 0) {
+    displayMessage('Place a line bet before rolling.');
+    return;
+  }
+
   clearDice();
 
-  const d1 = createDie(new THREE.Vector3(playerX - 0.3, 1.2, throwZ), diceMaterial);
-  const d2 = createDie(new THREE.Vector3(playerX + 0.3, 1.2, throwZ), diceMaterial);
+  const d1 = createDie(new THREE.Vector3(playerX - 0.3, 1.2, throwZ));
+  const d2 = createDie(new THREE.Vector3(playerX + 0.3, 1.2, throwZ));
 
   scene.add(d1.mesh, d2.mesh);
   world.addBody(d1.body);
@@ -59,7 +58,6 @@ function spawnDice() {
   });
 
   waitingForRollToSettle = true;
-  rollDisplayPending = true;
 }
 
 function clearDice() {
@@ -68,10 +66,6 @@ function clearDice() {
     world.removeBody(d.body);
   });
   dice = [];
-}
-
-function displayMessage(text) {
-  messagePanel.textContent = text;
 }
 
 function animate() {
@@ -83,32 +77,8 @@ function animate() {
     die.mesh.quaternion.copy(die.body.quaternion);
   });
 
-  if (waitingForRollToSettle) {
-    checkRoll({
-      dice,
-      waitingForRollToSettle,
-      rollDisplayPending,
-      rollTimer,
-      updateBalanceDisplay,
-      displayMessage,
-      clearDice,
-      clearChips,
-      updateChipDisplay,
-      scene,
-      playerX,
-      throwZ,
-      onRollComplete: () => {
-        waitingForRollToSettle = false;
-        rollDisplayPending = false;
-        rollTimer = 0;
-      },
-      incrementTimer: () => {
-        rollTimer += 1 / 60;
-      },
-      resetTimer: () => {
-        rollTimer = 0;
-      }
-    });
+  if (waitingForRollToSettle && checkRoll(dice)) {
+    waitingForRollToSettle = false;
   }
 
   renderer.render(scene, camera);

--- a/src/style.css
+++ b/src/style.css
@@ -24,12 +24,20 @@ button:hover {
 
 /* UI Panel Styles */
 #ui-panel {
+  position: absolute;
+  top: 10px;
+  left: 10px;
   background: rgba(0, 0, 0, 0.6);
   border-radius: 8px;
   padding: 12px;
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+
+#balance-display {
+  font-size: 18px;
+  margin-bottom: 8px;
 }
 
 /* Message Styling */

--- a/src/ui/balance.js
+++ b/src/ui/balance.js
@@ -3,14 +3,10 @@ import { player } from '../state/player.js';
 
 let balanceDisplay;
 
-export function initializeBalanceDisplay() {
+export function initializeBalanceDisplay(parent = document.body) {
   balanceDisplay = document.createElement('div');
-  balanceDisplay.style.position = 'absolute';
-  balanceDisplay.style.top = '120px';
-  balanceDisplay.style.left = '20px';
-  balanceDisplay.style.color = 'white';
-  balanceDisplay.style.fontSize = '18px';
-  document.body.appendChild(balanceDisplay);
+  balanceDisplay.id = 'balance-display';
+  parent.appendChild(balanceDisplay);
   updateBalanceDisplay();
 }
 

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -1,40 +1,31 @@
-import { updateBalanceDisplay } from '../state/player';
-import { placeBet } from '../betting/index';
-import { spawnDice } from '../dice/index';
 import { messagePanel, setupMessagePanel } from './message';
+import { initializeBalanceDisplay } from './balance';
 
 let uiPanel;
 
-export function setupUI(playerX, throwZ, scene) {
+export function setupUI(onRollDice, onPlaceBet) {
   // Main UI panel
   uiPanel = document.createElement('div');
-  uiPanel.style.position = 'absolute';
-  uiPanel.style.top = '10px';
-  uiPanel.style.left = '10px';
-  uiPanel.style.background = 'rgba(0, 0, 0, 0.5)';
-  uiPanel.style.padding = '10px';
-  uiPanel.style.borderRadius = '8px';
-  uiPanel.style.display = 'flex';
-  uiPanel.style.flexDirection = 'column';
-  uiPanel.style.gap = '10px';
+  uiPanel.id = 'ui-panel';
   document.body.appendChild(uiPanel);
+
+  initializeBalanceDisplay(uiPanel);
 
   // Roll Button
   const rollBtn = document.createElement('button');
   rollBtn.textContent = '🎲 Roll Dice';
-  rollBtn.onclick = () => spawnDice(playerX, throwZ, scene);
+  rollBtn.onclick = onRollDice;
   uiPanel.appendChild(rollBtn);
 
   // Chip betting buttons
   const chipContainer = document.createElement('div');
-  chipContainer.style.display = 'flex';
-  chipContainer.style.gap = '8px';
+  chipContainer.id = 'chip-container';
   uiPanel.appendChild(chipContainer);
 
   [5, 10, 25, 100].forEach(amount => {
     const chip = document.createElement('button');
     chip.textContent = `$${amount}`;
-    chip.onclick = () => placeBet(amount, playerX, throwZ, scene, updateBalanceDisplay);
+    chip.onclick = () => onPlaceBet(amount);
     chipContainer.appendChild(chip);
   });
 

--- a/src/ui/message.js
+++ b/src/ui/message.js
@@ -2,10 +2,7 @@ export let messagePanel;
 
 export function setupMessagePanel() {
   messagePanel = document.createElement('div');
-  messagePanel.style.color = 'white';
-  messagePanel.style.fontSize = '18px';
-  messagePanel.style.marginTop = '10px';
-  messagePanel.style.maxWidth = '320px';
+  messagePanel.id = 'messagePanel';
 }
 
 export function displayMessage(text) {


### PR DESCRIPTION
## Summary
- block bet placement after the point is established
- require a bet before rolling and keep dice visible after each roll

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684490b4d6c08324b90e0f548de49da5