### PR TITLE
Implement interactive physics for chips

### DIFF
--- a/src/betting/index.js
+++ b/src/betting/index.js
@@ -1,37 +1,167 @@
 import * as THREE from 'three';
-import { player } from '../state/player';
+import { Body, Cylinder, Vec3 } from 'cannon-es';
+import { chipMaterial } from '../environment/setup.js';
+import { player, gameState } from '../state/player';
+import { displayMessage } from '../ui/message';
+import { updateBalanceDisplay } from '../ui/balance';
 
 let betChips = [];
+let sceneRef = null;
+let worldRef = null;
+let slots = {};
 
-export function placeBet(amount, playerX, throwZ, scene, updateBalanceDisplay) {
-  if (!player.balance || player.balance < amount) return;
-  player.balance -= amount;
-  player.currentBet += amount;
-  updateBalanceDisplay();
-  updateChipDisplay(playerX, throwZ, scene);
+export function initBetting(scene, chipSlots, world) {
+  sceneRef = scene;
+  slots = chipSlots;
+  worldRef = world;
 }
 
-export function updateChipDisplay(playerX, throwZ, scene) {
-  clearChips(scene);
-  const chips = consolidateChips(player.currentBet);
-  const maxChipsPerStack = 20;
-  let stackCount = 0;
-  let chipIndex = 0;
+export function placeBet(amount) {
+  if (!gameState.canBet) {
+    displayMessage('Bets are locked until the round is over.');
+    return;
+  }
 
-  chips.forEach((value) => {
-    if (chipIndex >= maxChipsPerStack) {
-      stackCount++;
-      chipIndex = 0;
+  if (!player.balance || player.balance < amount) return;
+  player.balance -= amount;
+  player.lineBet += amount;
+  updateBalanceDisplay();
+  updateAllBetChips();
+}
+
+export function placeComeBet(amount) {
+  if (gameState.phase !== 'point') {
+    displayMessage('Come bets only allowed after the point is set.');
+    return;
+  }
+  if (player.balance < amount) return;
+  player.balance -= amount;
+  player.comeBets.push({ amount, point: null, odds: 0 });
+  updateBalanceDisplay();
+  updateAllBetChips();
+}
+
+export function placeDontPass(amount) {
+  if (gameState.phase !== 'comeOut') {
+    displayMessage("Don't Pass only on come out.");
+    return;
+  }
+  if (player.balance < amount) return;
+  player.balance -= amount;
+  player.dontPass += amount;
+  updateBalanceDisplay();
+  updateAllBetChips();
+}
+
+export function placeDontCome(amount) {
+  if (gameState.phase !== 'point') {
+    displayMessage("Don't Come only after point is set.");
+    return;
+  }
+  if (player.balance < amount) return;
+  player.balance -= amount;
+  player.dontComeBets.push({ amount, point: null, odds: 0 });
+  updateBalanceDisplay();
+  updateAllBetChips();
+}
+
+export function placeFieldBet(amount) {
+  if (player.balance < amount) return;
+  player.balance -= amount;
+  player.fieldBet += amount;
+  updateBalanceDisplay();
+  updateAllBetChips();
+}
+
+export function placeNumberBet(number, amount) {
+  if (!gameState.point) {
+    displayMessage('Place bets only after the point is set.');
+    return;
+  }
+  if (![4,5,6,8,9,10].includes(number)) return;
+  if (player.balance < amount) return;
+  player.balance -= amount;
+  player.placeBets[number] += amount;
+  updateBalanceDisplay();
+  updateAllBetChips();
+}
+
+export function placeOdds(type, point, amount) {
+  if (player.balance < amount) return;
+  if (type === 'line') {
+    if (gameState.phase !== 'point') {
+      displayMessage('Pass line odds only after a point.');
+      return;
     }
-    const chip = createChipMesh(value, playerX, stackCount, chipIndex, throwZ);
-    scene.add(chip);
-    betChips.push(chip);
-    chipIndex++;
+    player.balance -= amount;
+    player.lineOdds += amount;
+  } else if (type === 'come') {
+    const bet = player.comeBets.find(b => b.point === point);
+    if (!bet) return;
+    player.balance -= amount;
+    bet.odds = (bet.odds || 0) + amount;
+  } else if (type === 'dontCome') {
+    const bet = player.dontComeBets.find(b => b.point === point);
+    if (!bet) return;
+    player.balance -= amount;
+    bet.odds = (bet.odds || 0) + amount;
+  }
+  updateBalanceDisplay();
+  updateAllBetChips();
+}
+
+export function placeHardway(number, amount) {
+  if (![4,6,8,10].includes(number)) return;
+  if (player.balance < amount) return;
+  player.balance -= amount;
+  player.hardways[number] += amount;
+  updateBalanceDisplay();
+  updateAllBetChips();
+}
+
+export function updateAllBetChips() {
+  if (!sceneRef || !worldRef) return;
+  clearChips();
+
+  if (player.lineBet > 0 && slots.passLine) {
+    addChips(player.lineBet, slots.passLine, { kind: 'passLine' });
+  }
+  if (player.lineOdds > 0 && slots.lineOdds) {
+    addChips(player.lineOdds, slots.lineOdds, { kind: 'lineOdds' });
+  }
+  if (player.dontPass > 0 && slots.dontPass) {
+    addChips(player.dontPass, slots.dontPass, { kind: 'dontPass' });
+  }
+  if (player.fieldBet > 0 && slots.field) {
+    addChips(player.fieldBet, slots.field, { kind: 'field' });
+  }
+  player.comeBets.forEach(b => {
+    const total = b.amount + (b.odds || 0);
+    const key = b.point ? `come${b.point}` : 'come';
+    if (total > 0 && slots[key]) addChips(total, slots[key], { kind: 'come', bet: b });
+  });
+  Object.entries(player.placeBets).forEach(([n, amt]) => {
+    if (amt > 0 && slots[`place${n}`]) {
+      addChips(amt, slots[`place${n}`], { kind: 'place', point: Number(n) });
+    }
+  });
+  player.dontComeBets.forEach(b => {
+    const total = b.amount + (b.odds || 0);
+    const key = b.point ? `dontCome${b.point}` : 'dontCome';
+    if (total > 0 && slots[key]) addChips(total, slots[key], { kind: 'dontCome', bet: b });
+  });
+  Object.entries(player.hardways).forEach(([n, amt]) => {
+    if (amt > 0 && slots[`hard${n}`]) {
+      addChips(amt, slots[`hard${n}`], { kind: 'hardway', point: Number(n) });
+    }
   });
 }
 
-export function clearChips(scene) {
-  betChips.forEach(c => scene.remove(c));
+export function clearChips() {
+  betChips.forEach(c => {
+    if (c.mesh.parent) c.mesh.parent.remove(c.mesh);
+    if (worldRef && c.body) worldRef.removeBody(c.body);
+  });
   betChips = [];
 }
 
@@ -47,7 +177,7 @@ function consolidateChips(totalAmount) {
   return result;
 }
 
-function createChipMesh(amount, x, stackIndex, chipIndex, throwZ) {
+function createChipMesh(amount) {
   const chipHeight = 0.4;
   const geometry = new THREE.CylinderGeometry(0.5, 0.5, chipHeight, 32);
   const colorMap = {
@@ -59,12 +189,98 @@ function createChipMesh(amount, x, stackIndex, chipIndex, throwZ) {
     1000: 0xffff00
   };
   const material = new THREE.MeshStandardMaterial({ color: colorMap[amount] || 0xffffff });
-  const chip = new THREE.Mesh(geometry, material);
-  const spacing = 1.2;
-  chip.position.set(
-    x + stackIndex * spacing,
-    chipHeight / 2 + chipIndex * (chipHeight + 0.01),
-    throwZ - 3
-  );
-  return chip;
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.castShadow = true;
+  return mesh;
+}
+
+function addChips(amount, pos, info) {
+  if (!worldRef) return;
+  const chips = consolidateChips(amount);
+  const chipHeight = 0.4;
+  chips.forEach((value, idx) => {
+    const mesh = createChipMesh(value);
+    mesh.position.set(pos.x, chipHeight / 2 + idx * (chipHeight + 0.01), pos.z);
+    const shape = new Cylinder(0.5, 0.5, chipHeight, 16);
+    const body = new Body({
+      mass: 0.1,
+      material: chipMaterial,
+      shape,
+      position: new Vec3(mesh.position.x, mesh.position.y, mesh.position.z),
+      angularDamping: 0.9,
+      linearDamping: 0.9
+    });
+    sceneRef.add(mesh);
+    worldRef.addBody(body);
+    betChips.push({ mesh, body, value, info });
+  });
+}
+
+export function getChipMeshes() {
+  return betChips.map(c => c.mesh);
+}
+
+export function handleChipClick(mesh) {
+  const idx = betChips.findIndex(c => c.mesh === mesh);
+  if (idx === -1) return;
+  const chip = betChips[idx];
+  removeChipFromState(chip);
+  if (chip.mesh.parent) chip.mesh.parent.remove(chip.mesh);
+  if (worldRef) worldRef.removeBody(chip.body);
+  betChips.splice(idx, 1);
+  updateBalanceDisplay();
+  updateAllBetChips();
+}
+
+function removeChipFromState(chip) {
+  const { value, info } = chip;
+  player.balance += value;
+  switch (info.kind) {
+    case 'passLine':
+      player.lineBet = Math.max(0, player.lineBet - value);
+      break;
+    case 'lineOdds':
+      player.lineOdds = Math.max(0, player.lineOdds - value);
+      break;
+    case 'dontPass':
+      player.dontPass = Math.max(0, player.dontPass - value);
+      break;
+    case 'field':
+      player.fieldBet = Math.max(0, player.fieldBet - value);
+      break;
+    case 'place':
+      player.placeBets[info.point] = Math.max(0, player.placeBets[info.point] - value);
+      break;
+    case 'hardway':
+      player.hardways[info.point] = Math.max(0, player.hardways[info.point] - value);
+      break;
+    case 'come':
+      adjustBetObject(info.bet, value, player.comeBets);
+      break;
+    case 'dontCome':
+      adjustBetObject(info.bet, value, player.dontComeBets);
+      break;
+  }
+}
+
+function adjustBetObject(bet, value, list) {
+  if (!bet) return;
+  if (bet.odds >= value) {
+    bet.odds -= value;
+  } else {
+    const remain = value - bet.odds;
+    bet.odds = 0;
+    bet.amount -= remain;
+  }
+  if (bet.amount <= 0 && bet.odds <= 0) {
+    const i = list.indexOf(bet);
+    if (i !== -1) list.splice(i, 1);
+  }
+}
+
+export function updateChipMeshes() {
+  betChips.forEach(c => {
+    c.mesh.position.copy(c.body.position);
+    c.mesh.quaternion.copy(c.body.quaternion);
+  });
 }

--- a/src/dice/index.js
+++ b/src/dice/index.js
@@ -40,7 +40,7 @@ export function spawnDice(scene, world, playerX, throwZ) {
   const d2 = createDie(new THREE.Vector3(playerX + 0.3, 1.2, throwZ));
 
   dice.push(d1, d2);
-  scene.add(d1.mesh, d2.mesh);
+  scene.add(d1.mesh);
   scene.add(d2.mesh);
   world.addBody(d1.body);
   world.addBody(d2.body);

--- a/src/game/logic.js
+++ b/src/game/logic.js
@@ -27,13 +27,13 @@ export function checkRoll(dice) {
       if (gameState.phase === 'comeOut') {
         if (total === 7 || total === 11) {
           message = `🎯 You rolled ${total} — Natural! You win!`;
-          player.balance += player.currentBet * 2;
-          player.currentBet = 0;
+          player.balance += player.lineBet * 2;
+          player.lineBet = 0;
           gameState.canBet = true;
           clearChips();
         } else if ([2, 3, 12].includes(total)) {
           message = `💀 You rolled ${total} — Craps! You lose.`;
-          player.currentBet = 0;
+          player.lineBet = 0;
           gameState.canBet = true;
           clearChips();
         } else {
@@ -45,15 +45,15 @@ export function checkRoll(dice) {
       } else if (gameState.phase === 'point') {
         if (total === gameState.point) {
           message = `🎉 You hit the point (${total}) — You win!`;
-          player.balance += player.currentBet * 2;
-          player.currentBet = 0;
+          player.balance += player.lineBet * 2;
+          player.lineBet = 0;
           gameState.phase = 'comeOut';
           gameState.point = null;
           gameState.canBet = true;
           clearChips();
         } else if (total === 7) {
           message = `💥 You rolled a 7 before the point — You lose.`;
-          player.currentBet = 0;
+          player.lineBet = 0;
           gameState.phase = 'comeOut';
           gameState.point = null;
           gameState.canBet = true;

--- a/src/logic/rollHandler.js
+++ b/src/logic/rollHandler.js
@@ -1,13 +1,244 @@
 // src/logic/rollHandler.js
 import { getTopFace } from '../dice/index';
-import { player, gameState, updateBalanceDisplay } from '../state/player';
+import { player, gameState } from '../state/player';
+import { updateBalanceDisplay } from '../ui/balance';
 import { displayMessage } from '../ui/message';
-import { clearChips } from '../betting';
+import { clearChips, updateAllBetChips } from '../betting';
 
 let rollTimer = 0;
 
+function payoutOdds(point, amount) {
+  switch (point) {
+    case 4:
+    case 10:
+      return amount * 2;
+    case 5:
+    case 9:
+      return Math.round(amount * 1.5);
+    case 6:
+    case 8:
+      return Math.round(amount * 1.2);
+    default:
+      return amount;
+  }
+}
+
+function payoutPlace(point, amount) {
+  switch (point) {
+    case 4:
+    case 10:
+      return Math.round(amount * 9 / 5);
+    case 5:
+    case 9:
+      return Math.round(amount * 7 / 5);
+    case 6:
+    case 8:
+      return Math.round(amount * 7 / 6);
+    default:
+      return 0;
+  }
+}
+
+function resolveBets(r1, r2, total) {
+  let messages = [];
+
+  // Field bet (one roll)
+  if (player.fieldBet > 0) {
+    if ([3, 4, 9, 10, 11].includes(total)) {
+      player.balance += player.fieldBet * 2;
+      messages.push(`Field bet wins on ${total}!`);
+    } else if (total === 2 || total === 12) {
+      player.balance += player.fieldBet * 3;
+      messages.push(`Field bet pays double on ${total}!`);
+    } else {
+      messages.push('Field bet loses.');
+    }
+    player.fieldBet = 0;
+  }
+
+  // Hardways
+  const hardNumbers = [4, 6, 8, 10];
+  for (const n of hardNumbers) {
+    const amt = player.hardways[n];
+    if (!amt) continue;
+    const pair = n / 2;
+    if (r1 === pair && r2 === pair) {
+      const payout = n === 6 || n === 8 ? amt * 9 : amt * 7;
+      player.balance += payout;
+      messages.push(`Hard ${n} pays ${payout}!`);
+      player.hardways[n] = 0;
+    } else if (total === 7 || total === n) {
+      player.hardways[n] = 0;
+      messages.push(`Hard ${n} loses.`);
+    }
+  }
+
+  // Place bets
+  if (gameState.phase === 'point') {
+    const placeNumbers = [4, 5, 6, 8, 9, 10];
+    for (const n of placeNumbers) {
+      const amt = player.placeBets[n];
+      if (!amt) continue;
+      if (total === n) {
+        player.balance += payoutPlace(n, amt);
+        messages.push(`Place ${n} pays!`);
+      } else if (total === 7) {
+        player.placeBets[n] = 0;
+        messages.push(`Place ${n} loses.`);
+      }
+    }
+  }
+
+  // Come bets
+  player.comeBets = player.comeBets.filter(bet => {
+    if (!bet.point) {
+      if (total === 7 || total === 11) {
+        player.balance += bet.amount * 2;
+        messages.push(`Come bet wins on ${total}.`);
+        return false;
+      }
+      if ([2, 3, 12].includes(total)) {
+        messages.push(`Come bet loses on ${total}.`);
+        return false;
+      }
+      bet.point = total;
+      messages.push(`Come bet moves to ${total}.`);
+      return true;
+    }
+
+    if (total === bet.point) {
+      let win = bet.amount * 2;
+      if (bet.odds) win += payoutOdds(bet.point, bet.odds) + bet.odds;
+      player.balance += win;
+      messages.push(`Come bet on ${bet.point} wins.`);
+      return false;
+    }
+    if (total === 7) {
+      messages.push(`Come bet on ${bet.point} loses.`);
+      return false;
+    }
+    return true;
+  });
+
+  // Don't come bets
+  player.dontComeBets = player.dontComeBets.filter(bet => {
+    if (!bet.point) {
+      if ([2, 3].includes(total)) {
+        player.balance += bet.amount * 2;
+        messages.push(`Don't come wins on ${total}.`);
+        return false;
+      }
+      if (total === 7 || total === 11) {
+        messages.push("Don't come loses.");
+        return false;
+      }
+      if (total === 12) {
+        player.balance += bet.amount;
+        messages.push("Don't come pushes on 12.");
+        return false;
+      }
+      bet.point = total;
+      messages.push(`Don't come moves behind ${total}.`);
+      return true;
+    }
+
+    if (total === 7) {
+      let win = bet.amount * 2;
+      if (bet.odds) win += payoutOdds(bet.point, bet.odds) + bet.odds;
+      player.balance += win;
+      messages.push(`Don't come on ${bet.point} wins.`);
+      return false;
+    }
+    if (total === bet.point) {
+      messages.push(`Don't come on ${bet.point} loses.`);
+      return false;
+    }
+    return true;
+  });
+
+  // Pass line
+  if (gameState.phase === 'comeOut') {
+    if (player.lineBet > 0 || player.dontPass > 0) {
+      if (total === 7 || total === 11) {
+        if (player.lineBet > 0) {
+          player.balance += player.lineBet * 2 + payoutOdds(total, player.lineOdds);
+          player.lineBet = 0;
+          player.lineOdds = 0;
+          messages.push('Pass line wins.');
+        }
+        if (player.dontPass > 0) {
+          messages.push("Don't pass loses.");
+          player.dontPass = 0;
+        }
+        gameState.canBet = true;
+        clearChips();
+        updateAllBetChips();
+      } else if ([2, 3, 12].includes(total)) {
+        if (player.lineBet > 0) {
+          messages.push('Pass line loses.');
+          player.lineBet = 0;
+          player.lineOdds = 0;
+          clearChips();
+          updateAllBetChips();
+        }
+        if (total === 12 && player.dontPass > 0) {
+          player.balance += player.dontPass; // push
+          messages.push("Don't pass pushes on 12.");
+          player.dontPass = 0;
+        } else if ([2, 3].includes(total) && player.dontPass > 0) {
+          player.balance += player.dontPass * 2;
+          messages.push("Don't pass wins.");
+          player.dontPass = 0;
+        }
+        gameState.canBet = true;
+      } else {
+        gameState.phase = 'point';
+        gameState.point = total;
+        gameState.canBet = true; // allow odds/come
+        messages.push(`Point is ${total}.`);
+      }
+    }
+  } else if (gameState.phase === 'point') {
+    if (total === gameState.point) {
+      if (player.lineBet > 0) {
+        let win = player.lineBet * 2;
+        if (player.lineOdds) win += payoutOdds(gameState.point, player.lineOdds) + player.lineOdds;
+        player.balance += win;
+        messages.push('Pass line wins!');
+      }
+      if (player.dontPass > 0) {
+        messages.push("Don't pass loses.");
+      }
+      player.lineBet = 0;
+      player.dontPass = 0;
+      player.lineOdds = 0;
+      gameState.phase = 'comeOut';
+      gameState.point = null;
+      gameState.canBet = true;
+      clearChips();
+      updateAllBetChips();
+    } else if (total === 7) {
+      if (player.lineBet > 0) messages.push('Pass line loses.');
+      if (player.dontPass > 0) {
+        player.balance += player.dontPass * 2;
+        messages.push("Don't pass wins!");
+      }
+      player.lineBet = 0;
+      player.dontPass = 0;
+      player.lineOdds = 0;
+      gameState.phase = 'comeOut';
+      gameState.point = null;
+      gameState.canBet = true;
+      clearChips();
+      updateAllBetChips();
+    }
+  }
+
+  return messages.join(' ');
+}
+
 export function checkRoll(dice) {
-  if (!dice || dice.length !== 2) return;
+  if (!dice || dice.length !== 2) return false;
 
   const [d1, d2] = dice;
   const still1 = d1.body.velocity.length() < 0.1 && d1.body.angularVelocity.length() < 0.1;
@@ -20,50 +251,13 @@ export function checkRoll(dice) {
       const r2 = getTopFace(d2);
       const total = r1 + r2;
       gameState.lastRoll = total;
-      let message = '';
 
-      if (gameState.phase === 'comeOut') {
-        if (total === 7 || total === 11) {
-          message = `🎯 You rolled ${total} — Natural! You win!`;
-          player.balance += player.currentBet * 2;
-          player.currentBet = 0;
-          gameState.canBet = true;
-          clearChips();
-        } else if ([2, 3, 12].includes(total)) {
-          message = `💀 You rolled ${total} — Craps! You lose.`;
-          player.currentBet = 0;
-          gameState.canBet = true;
-          clearChips();
-        } else {
-          gameState.phase = 'point';
-          gameState.point = total;
-          gameState.canBet = false;
-          message = `Point is now set to ${total}. Roll again to hit the point before a 7.`;
-        }
-      } else if (gameState.phase === 'point') {
-        if (total === gameState.point) {
-          message = `🎉 You hit the point (${total}) — You win!`;
-          player.balance += player.currentBet * 2;
-          player.currentBet = 0;
-          gameState.phase = 'comeOut';
-          gameState.point = null;
-          gameState.canBet = true;
-          clearChips();
-        } else if (total === 7) {
-          message = `💥 You rolled a 7 before the point — You lose.`;
-          player.currentBet = 0;
-          gameState.phase = 'comeOut';
-          gameState.point = null;
-          gameState.canBet = true;
-          clearChips();
-        } else {
-          message = `You rolled ${total}. Keep going!`;
-        }
-      }
+      const message = resolveBets(r1, r2, total) || `You rolled ${total}.`;
 
       displayMessage(message);
       updateBalanceDisplay();
-      return true; // roll is resolved
+      updateAllBetChips();
+      return true; // roll resolved
     }
   } else {
     rollTimer = 0;
@@ -71,3 +265,4 @@ export function checkRoll(dice) {
 
   return false; // still rolling
 }
+

--- a/src/main.js
+++ b/src/main.js
@@ -2,44 +2,77 @@
 import * as THREE from 'three';
 import { Vec3 } from 'cannon-es';
 
-import { setupSceneAndRenderer, setupPhysicsWorld, setupTableAndWalls } from './environment/setup.js';
-
+import {
+  setupSceneAndRenderer,
+  setupPhysicsWorld,
+  setupTableAndWalls
+} from './environment/setup.js';
 
 
 import { initControls } from './ui/controls.js';
-import { createDie, getTopFace } from './dice/index.js';
-import { initializeBalanceDisplay, updateBalanceDisplay } from './ui/balance.js';
-import { placeBet, updateChipDisplay, clearChips } from './betting/index.js';
-import { setupUI, messagePanel } from './ui/index.js';
+import { createDie } from './dice/index.js';
+import {
+  initBetting,
+  placeBet,
+  placeComeBet,
+  placeDontPass,
+  placeDontCome,
+  placeFieldBet,
+  placeOdds,
+  placeHardway,
+  placeNumberBet
+} from './betting/index.js';
+import { setupUI } from './ui/index.js';
+import { getChipMeshes, handleChipClick, updateChipMeshes } from './betting/index.js';
 import { checkRoll } from './logic/rollHandler.js';
+import { player, gameState } from './state/player.js';
+import { displayMessage } from './ui/message.js';
 
-const {
-  scene,
-  camera,
-  renderer,
-  throwZ,
-  diceMaterial,
-  world,
-  tableWidth
-} = setupSceneAndRenderer();
-
-setupPhysicsWorld(world);
-setupTableAndWalls(scene, world);
+const { scene, camera, renderer } = setupSceneAndRenderer();
+const world = setupPhysicsWorld();
+const { tableWidth, chipSlots } = setupTableAndWalls(scene, world);
+const throwZ = tableWidth / 2 - 4;
 initControls(camera, renderer);
-initializeBalanceDisplay();
-setupUI(() => spawnDice(), (amount) => placeBet(amount, playerX, throwZ, scene, updateBalanceDisplay));
+
+initBetting(scene, chipSlots, world);
+setupUI({
+  onRollDice: spawnDice,
+  onLineBet: (amount) => placeBet(amount),
+  onComeBet: (amount) => placeComeBet(amount),
+  onDontPass: (amount) => placeDontPass(amount),
+  onDontCome: (amount) => placeDontCome(amount),
+  onFieldBet: (amount) => placeFieldBet(amount),
+  onOddsLine: (amount) => placeOdds('line', null, amount),
+  onHardway: (number, amount) => placeHardway(number, amount),
+  onPlaceBet: (number, amount) => placeNumberBet(number, amount)
+});
+
+const raycaster = new THREE.Raycaster();
+const mouse = new THREE.Vector2();
+window.addEventListener('pointerdown', (event) => {
+  mouse.x = (event.clientX / window.innerWidth) * 2 - 1;
+  mouse.y = -(event.clientY / window.innerHeight) * 2 + 1;
+  raycaster.setFromCamera(mouse, camera);
+  const intersect = raycaster.intersectObjects(getChipMeshes(), true);
+  if (intersect.length) {
+    handleChipClick(intersect[0].object);
+  }
+});
 
 let playerX = 0;
 let dice = [];
 let waitingForRollToSettle = false;
-let rollDisplayPending = false;
-let rollTimer = 0;
 
 function spawnDice() {
+  if (gameState.phase === 'comeOut' && player.lineBet === 0) {
+    displayMessage('Place a line bet before rolling.');
+    return;
+  }
+
   clearDice();
 
-  const d1 = createDie(new THREE.Vector3(playerX - 0.3, 1.2, throwZ), diceMaterial);
-  const d2 = createDie(new THREE.Vector3(playerX + 0.3, 1.2, throwZ), diceMaterial);
+  const d1 = createDie(new THREE.Vector3(playerX - 0.3, 1.2, throwZ));
+  const d2 = createDie(new THREE.Vector3(playerX + 0.3, 1.2, throwZ));
 
   scene.add(d1.mesh, d2.mesh);
   world.addBody(d1.body);
@@ -59,7 +92,6 @@ function spawnDice() {
   });
 
   waitingForRollToSettle = true;
-  rollDisplayPending = true;
 }
 
 function clearDice() {
@@ -70,10 +102,6 @@ function clearDice() {
   dice = [];
 }
 
-function displayMessage(text) {
-  messagePanel.textContent = text;
-}
-
 function animate() {
   requestAnimationFrame(animate);
   world.step(1 / 60);
@@ -82,33 +110,10 @@ function animate() {
     die.mesh.position.copy(die.body.position);
     die.mesh.quaternion.copy(die.body.quaternion);
   });
+  updateChipMeshes();
 
-  if (waitingForRollToSettle) {
-    checkRoll({
-      dice,
-      waitingForRollToSettle,
-      rollDisplayPending,
-      rollTimer,
-      updateBalanceDisplay,
-      displayMessage,
-      clearDice,
-      clearChips,
-      updateChipDisplay,
-      scene,
-      playerX,
-      throwZ,
-      onRollComplete: () => {
-        waitingForRollToSettle = false;
-        rollDisplayPending = false;
-        rollTimer = 0;
-      },
-      incrementTimer: () => {
-        rollTimer += 1 / 60;
-      },
-      resetTimer: () => {
-        rollTimer = 0;
-      }
-    });
+  if (waitingForRollToSettle && checkRoll(dice)) {
+    waitingForRollToSettle = false;
   }
 
   renderer.render(scene, camera);

--- a/src/state/player.js
+++ b/src/state/player.js
@@ -1,6 +1,33 @@
 export const player = {
   balance: 500,
-  currentBet: 0
+  // Pass line bet
+  lineBet: 0,
+  // Don't pass bet
+  dontPass: 0,
+  // Active come bets { amount, point, odds }
+  comeBets: [],
+  // Active don't come bets { amount, point, odds }
+  dontComeBets: [],
+  // One-roll field bet
+  fieldBet: 0,
+  // Hardway bets keyed by number (4,6,8,10)
+  hardways: {
+    4: 0,
+    6: 0,
+    8: 0,
+    10: 0
+  },
+  // Place bets keyed by number (4,5,6,8,9,10)
+  placeBets: {
+    4: 0,
+    5: 0,
+    6: 0,
+    8: 0,
+    9: 0,
+    10: 0
+  },
+  // Odds on the pass line
+  lineOdds: 0
 };
 
 export const gameState = {
@@ -11,7 +38,13 @@ export const gameState = {
 };
 
 export function updateBalanceDisplay(balanceDisplay) {
-  balanceDisplay.innerText = `Balance: $${player.balance} | Bet: $${player.currentBet}`;
+  const comeTotal = player.comeBets.reduce((t, b) => t + b.amount + (b.odds || 0), 0);
+  const dontComeTotal = player.dontComeBets.reduce((t, b) => t + b.amount + (b.odds || 0), 0);
+  const hardwayTotal = Object.values(player.hardways).reduce((t, v) => t + v, 0);
+  const placeTotal = Object.values(player.placeBets).reduce((t, v) => t + v, 0);
+  const totalBet =
+    player.lineBet + player.dontPass + comeTotal + dontComeTotal + placeTotal + player.fieldBet + hardwayTotal + player.lineOdds;
+  balanceDisplay.innerText = `Balance: $${player.balance} | Total Bets: $${totalBet}`;
 }
 
 export function displayMessage(messagePanel, text) {

--- a/src/style.css
+++ b/src/style.css
@@ -24,12 +24,20 @@ button:hover {
 
 /* UI Panel Styles */
 #ui-panel {
+  position: absolute;
+  top: 10px;
+  left: 10px;
   background: rgba(0, 0, 0, 0.6);
   border-radius: 8px;
   padding: 12px;
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+
+#balance-display {
+  font-size: 18px;
+  margin-bottom: 8px;
 }
 
 /* Message Styling */
@@ -43,4 +51,19 @@ button:hover {
 #chip-container {
   display: flex;
   gap: 10px;
+}
+
+.active {
+  background-color: #777;
+}
+
+#hard-container {
+  display: flex;
+  gap: 6px;
+}
+
+#place-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
 }

--- a/src/ui/balance.js
+++ b/src/ui/balance.js
@@ -1,21 +1,35 @@
 // src/ui/balance.js
-import { player } from '../state/player.js';
+import { player, gameState } from '../state/player.js';
 
 let balanceDisplay;
 
-export function initializeBalanceDisplay() {
+export function initializeBalanceDisplay(parent = document.body) {
   balanceDisplay = document.createElement('div');
-  balanceDisplay.style.position = 'absolute';
-  balanceDisplay.style.top = '120px';
-  balanceDisplay.style.left = '20px';
-  balanceDisplay.style.color = 'white';
-  balanceDisplay.style.fontSize = '18px';
-  document.body.appendChild(balanceDisplay);
+  balanceDisplay.id = 'balance-display';
+  parent.appendChild(balanceDisplay);
   updateBalanceDisplay();
 }
 
 export function updateBalanceDisplay() {
-  if (balanceDisplay) {
-    balanceDisplay.innerText = `Balance: $${player.balance} | Bet: $${player.currentBet}`;
-  }
+  if (!balanceDisplay) return;
+
+  const comeTotal = player.comeBets.reduce((t, b) => t + b.amount + (b.odds || 0), 0);
+  const dontComeTotal = player.dontComeBets.reduce((t, b) => t + b.amount + (b.odds || 0), 0);
+  const hardwayTotal = Object.values(player.hardways).reduce((t, v) => t + v, 0);
+  const placeTotal = Object.values(player.placeBets).reduce((t, v) => t + v, 0);
+
+  const parts = [
+    `Pass Line: $${player.lineBet}`,
+    player.lineOdds ? `Odds: $${player.lineOdds}` : null,
+    player.dontPass ? `Don't Pass: $${player.dontPass}` : null,
+    player.fieldBet ? `Field: $${player.fieldBet}` : null,
+    comeTotal ? `Come: $${comeTotal}` : null,
+    placeTotal ? `Place: $${placeTotal}` : null,
+    dontComeTotal ? `Don't Come: $${dontComeTotal}` : null,
+    hardwayTotal ? `Hardways: $${hardwayTotal}` : null
+  ].filter(Boolean);
+
+  const point = gameState.point ? ` | Point: ${gameState.point}` : '';
+
+  balanceDisplay.innerText = `Balance: $${player.balance}${point}\n${parts.join(' | ')}`;
 }

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -1,41 +1,82 @@
-import { updateBalanceDisplay } from '../state/player';
-import { placeBet } from '../betting/index';
-import { spawnDice } from '../dice/index';
 import { messagePanel, setupMessagePanel } from './message';
+import { initializeBalanceDisplay } from './balance';
 
 let uiPanel;
 
-export function setupUI(playerX, throwZ, scene) {
+export function setupUI({
+  onRollDice,
+  onLineBet,
+  onComeBet,
+  onDontPass,
+  onDontCome,
+  onFieldBet,
+  onOddsLine,
+  onHardway,
+  onPlaceBet
+}) {
   // Main UI panel
   uiPanel = document.createElement('div');
-  uiPanel.style.position = 'absolute';
-  uiPanel.style.top = '10px';
-  uiPanel.style.left = '10px';
-  uiPanel.style.background = 'rgba(0, 0, 0, 0.5)';
-  uiPanel.style.padding = '10px';
-  uiPanel.style.borderRadius = '8px';
-  uiPanel.style.display = 'flex';
-  uiPanel.style.flexDirection = 'column';
-  uiPanel.style.gap = '10px';
+  uiPanel.id = 'ui-panel';
   document.body.appendChild(uiPanel);
+
+  initializeBalanceDisplay(uiPanel);
 
   // Roll Button
   const rollBtn = document.createElement('button');
   rollBtn.textContent = '🎲 Roll Dice';
-  rollBtn.onclick = () => spawnDice(playerX, throwZ, scene);
+  rollBtn.onclick = onRollDice;
   uiPanel.appendChild(rollBtn);
 
-  // Chip betting buttons
-  const chipContainer = document.createElement('div');
-  chipContainer.style.display = 'flex';
-  chipContainer.style.gap = '8px';
-  uiPanel.appendChild(chipContainer);
+  // Chip denomination selector
+  let selected = 5;
+  const denom = document.createElement('div');
+  denom.id = 'chip-container';
+  uiPanel.appendChild(denom);
+  [1,5,25,100].forEach(val => {
+    const btn = document.createElement('button');
+    btn.textContent = `$${val}`;
+    if (val === selected) btn.classList.add('active');
+    btn.onclick = () => {
+      selected = val;
+      Array.from(denom.children).forEach(c => c.classList.remove('active'));
+      btn.classList.add('active');
+    };
+    denom.appendChild(btn);
+  });
 
-  [5, 10, 25, 100].forEach(amount => {
-    const chip = document.createElement('button');
-    chip.textContent = `$${amount}`;
-    chip.onclick = () => placeBet(amount, playerX, throwZ, scene, updateBalanceDisplay);
-    chipContainer.appendChild(chip);
+  const makeBtn = (label, handler) => {
+    const b = document.createElement('button');
+    b.textContent = label;
+    b.onclick = () => handler(selected);
+    uiPanel.appendChild(b);
+  };
+
+  makeBtn('Pass Line', onLineBet);
+  makeBtn("Don't Pass", onDontPass);
+  makeBtn('Come', onComeBet);
+  makeBtn("Don't Come", onDontCome);
+  makeBtn('Field', onFieldBet);
+  makeBtn('Pass Odds', amt => onOddsLine(amt));
+
+  const placeContainer = document.createElement('div');
+  placeContainer.id = 'place-container';
+  uiPanel.appendChild(placeContainer);
+  [4,5,6,8,9,10].forEach(n => {
+    const btn = document.createElement('button');
+    btn.textContent = `Place ${n}`;
+    btn.onclick = () => onPlaceBet(n, selected);
+    placeContainer.appendChild(btn);
+  });
+
+  // Hardway buttons
+  const hardContainer = document.createElement('div');
+  hardContainer.id = 'hard-container';
+  uiPanel.appendChild(hardContainer);
+  [4,6,8,10].forEach(n => {
+    const btn = document.createElement('button');
+    btn.textContent = `Hard ${n}`;
+    btn.onclick = () => onHardway(n, selected);
+    hardContainer.appendChild(btn);
   });
 
   // Message panel

--- a/src/ui/message.js
+++ b/src/ui/message.js
@@ -2,10 +2,7 @@ export let messagePanel;
 
 export function setupMessagePanel() {
   messagePanel = document.createElement('div');
-  messagePanel.style.color = 'white';
-  messagePanel.style.fontSize = '18px';
-  messagePanel.style.marginTop = '10px';
-  messagePanel.style.maxWidth = '320px';
+  messagePanel.id = 'messagePanel';
 }
 
 export function displayMessage(text) {


### PR DESCRIPTION
## Summary
- expose chip physics material and contact interactions
- track chip meshes with physics bodies for each bet
- allow players to click chips to remove a portion of a wager
- update chip positions each frame and handle click raycasting
- keep place bets off on the come-out roll and adjust chip click intersection

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684490b4d6c08324b90e0f548de49da5